### PR TITLE
Add a basic countermeasure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: '📦 Release'
 
-on: release
+on:
+  release:
+    types: [ created ]
 
 jobs:
   release:

--- a/device-identifier/shbdeviceidentifier/app.py
+++ b/device-identifier/shbdeviceidentifier/app.py
@@ -11,6 +11,7 @@ from loguru import logger
 from pyfiglet import Figlet
 
 import shbdeviceidentifier.commands as commands
+from .countermeasures import COUNTERMEASURES
 from .db import Database
 from .utilities import get_capture_file_path, logger_wraps
 from .utilities.app_utilities import DATA_DIR, resolve_file_path
@@ -150,9 +151,18 @@ def start(ctx):
 @click.option(
     "--measurement", "-m", help="Name of the measurement in the InfluxDB. Defaults to `main`.", required=False
 )
+@click.option(
+    "--countermeasure",
+    "-c",
+    "countermeasure_key",
+    help="Name of the countermeasure to apply on the pcap before saving.",
+    type=click.Choice(COUNTERMEASURES.keys(), case_sensitive=True),
+    required=False,
+    default=None,
+)
 @pass_ctx
 @logger_wraps()
-def read(ctx, file_path: click.Path, file_type: str, measurement: str):
+def read(ctx, file_path: click.Path, file_type: str, measurement: str, countermeasure_key: str):
     """Reads all the data from a capture file."""
     file_path = get_capture_file_path(ctx, file_path)
     if not file_path:
@@ -161,7 +171,8 @@ def read(ctx, file_path: click.Path, file_type: str, measurement: str):
 
     if not measurement:
         measurement = ctx.measurement
-    commands.read(ctx.db, file_path, file_type, measurement)
+
+    commands.read(ctx.db, file_path, file_type, measurement, countermeasure_key)
 
 
 @app.command("read-labels")

--- a/device-identifier/shbdeviceidentifier/countermeasures.py
+++ b/device-identifier/shbdeviceidentifier/countermeasures.py
@@ -1,0 +1,21 @@
+import pandas as pd
+
+
+def shaping_v0(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Countermeasure: Traffic Shaping
+    Version: v0
+
+    Pads all packets to the maximum packet size found in the capture.
+    This reduces prediction accuracy for models relying on the packet size.
+    """
+    # Find the biggest packet
+    max_size = df['data_len'].max()
+
+    # Pad all elements to the size of the biggest packet
+    df['data_len'].values[:] = max_size
+
+    return df
+
+
+COUNTERMEASURES = {"shaping_v0": shaping_v0}

--- a/device-identifier/shbdeviceidentifier/dataloader.py
+++ b/device-identifier/shbdeviceidentifier/dataloader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, List, Union, Generator, Tuple, Dict
+from typing import Optional, List, Union, Generator, Tuple, Dict, Callable
 
 import pandas as pd
 from loguru import logger
@@ -66,7 +66,7 @@ class DataLoader:
             return pd.read_csv(file_path, **kwargs)
 
     @staticmethod
-    def from_pcap(file_path: Union[Path, str]) -> Optional[pd.DataFrame]:
+    def from_pcap(file_path: Union[Path, str], countermeasure: Callable = None) -> Optional[pd.DataFrame]:
         """
         Loads data from a pcap file.
         """
@@ -80,7 +80,14 @@ class DataLoader:
         if file_path:
             # Read pcap
             cap = rdpcap(file_path.as_posix())
+
+            # Convert to DataFrame
             df = convert_Capture_to_DataFrame(cap)
+
+            # Apply countermeasure
+            if countermeasure:
+                df = countermeasure(df)
+
             if not df.empty:
                 return df
 

--- a/device-identifier/shbdeviceidentifier/db.py
+++ b/device-identifier/shbdeviceidentifier/db.py
@@ -380,10 +380,7 @@ class Database:
             # Do not send to error log when only the UNIQUE constraint is violated.
             # Send to debug instead.
             if isinstance(err, sqlite3.IntegrityError):
-                lines = traceback.format_exc().splitlines()
-                for line in lines:
-                    logger.debug(line)
-                logger.debug(f"The supplied statements are: {params}")
+                logger.debug(f"{err} for {params}")
             else:
                 lines = traceback.format_exc().splitlines()
                 for line in lines:


### PR DESCRIPTION
Added a countermeasure that pads the packet sizes to the maximum length found in the capture. This reduces prediction accuracy significantly, but will have performance issues when used with a live stream (not implemented). 